### PR TITLE
Ensure `(defn- as-path)` form is fully declared for Clojure 1.5 compatibility.

### DIFF
--- a/src/org/bovinegenius/exploding_fish.clj
+++ b/src/org/bovinegenius/exploding_fish.clj
@@ -489,13 +489,14 @@ given, set the nth param value that matches the given key."
   (->> (path uri) path/normalize (path uri)))
 
 (defn- as-path
-  "Ensure path")
+  "Ensure path"
+  [p] 
+  (path (uri p)))
 
 (defn resolve-path
   "Resolve the given path against the given uri."
   [the-uri the-path]
-  (letfn [(as-path [p] (path (uri p)))]
-    (path the-uri (-> (path the-uri) (path/resolve-path (as-path the-path))))))
+    (path the-uri (-> (path the-uri) (path/resolve-path (as-path the-path)))))
 
 (defn absolute-path?
   "Returns true if the given uri path is absolute."


### PR DESCRIPTION
While Clojure 1.4 silently accepts the incomplete form:

``` clojure
(defn- as-path
  "Ensure path")
```

Clojure 1.5 is more particular, causing failure when requiring the `org.bovinegenius.exploding-fish` namespace:

```
user> (require 'org.bovinegenius.exploding-fish :reload-all)
IllegalArgumentException Parameter declaration missing  clojure.core/assert-valid-fdecl (core.clj:6716)
```

`as-path` was fully re-declared in a `letfn` inside `resolve-path`, so I've simply extracted the internal declaration
and inserted it in the top-level `as-path`, making the top-level form complete.
