### PR TITLE
resolve-uri with a target-uri on a different host

### DIFF
--- a/src/org/bovinegenius/exploding_fish.clj
+++ b/src/org/bovinegenius/exploding_fish.clj
@@ -522,10 +522,19 @@ this document: http://www.ics.uci.edu/~fielding/url/test2.html"
     ;; need to handle this case separately:
     ;; resolve-uri "http://a/b/c" "//c"
     ;; since path is nil, the resolve fails
-    (if (re-find #"^//" (str target-uri))
-      (scheme target-uri
-              (scheme src-uri))
-      (-> src-uri
-         (resolve-path target-uri)
-         (query target-uri-query)
-         (fragment target-uri-fragment)))))
+    (cond
+     (re-find #"^//" (str target-uri))
+     (scheme target-uri
+             (scheme src-uri))
+
+     (absolute? target-uri)   ; this is the second condition we match
+     target-uri               ; against since (absolute? //a/b) => #t
+                              ; and we want (resolve-uri "http:/a/b"
+                              ; "http://c/d") to resolve to the target
+                              ; URI itself
+     
+     :else
+     (-> src-uri
+        (resolve-path target-uri)
+        (query target-uri-query)
+        (fragment target-uri-fragment)))))

--- a/test/org/bovinegenius/uri_test.clj
+++ b/test/org/bovinegenius/uri_test.clj
@@ -238,6 +238,9 @@
 
 (deftest resolve-uri-test
   (let [the-base-uri "http://a/b/c/d;p?q=1/2"]
+    (is (let [diff-host-uri "http://e/f"]
+         (= (resolve-uri the-base-uri diff-host-uri)
+            diff-host-uri)))
     (is (= (resolve-uri the-base-uri "g")
            "http://a/b/c/g"))
     (is (= (resolve-uri the-base-uri "./g")


### PR DESCRIPTION
Previously:
(resolve-uri "http://a/b" "http://c/d") => "http://a/d" which is not correct. this is fixed.
