### PR TITLE
Update .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
+/target
+/lib
+/classes
+/checkouts
 pom.xml
+pom.xml.asc
 *.jar
 *.class
-lib
-classes
-*~
 .lein-deps-sum
 .lein-failures
+.lein-plugins
+.lein-repl-history


### PR DESCRIPTION
Update .gitignore to match recent Leiningen default, in particular ignoring target/.
