### PR TITLE
Parse literal IPv6 addresses in hostnames

### DIFF
--- a/src/org/bovinegenius/exploding_fish/parser.clj
+++ b/src/org/bovinegenius/exploding_fish/parser.clj
@@ -30,7 +30,7 @@
 
 (defn generic
   "Takes a URI string and parses it into scheme, scheme-relative,
-and fragment parts."  
+and fragment parts."
   [^String uri]
   (if uri
     (let [[_ scheme ssp fragment] (or (re-find #"^([a-zA-Z][a-zA-Z\d+.-]*):([^#]+)#?(.*)$" uri)
@@ -60,7 +60,7 @@ parts."
   "Parse the authority part into user-info, hostname, and port parts."
   [authority]
   (if authority
-    (let [[_ user-info host port] (re-find #"^([^@]+(?=@))?@?([^:]+):?(.*)$" authority)
+    (let [[_ user-info host port] (re-find #"^([^@]+(?=@))?@?([^:]+|\[[0-9a-fA-F:]*\]):?(\d*)$" authority)
           port (if (empty? port) nil (Integer/parseInt port))]
       {:user-info user-info :host host :port port})
     {:user-info nil :host nil :port nil}))

--- a/test/org/bovinegenius/uri_test.clj
+++ b/test/org/bovinegenius/uri_test.clj
@@ -30,6 +30,14 @@
             :authority "www.fred.net",
             :scheme "http",
             :scheme-relative "//www.fred.net/"})))
+  (let [uri-string "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html"]
+    (is (= (into {} (uri uri-string))
+           {:scheme "http"
+            :scheme-relative "//[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html"
+            :authority  "[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80"
+            :host "[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]"
+            :port 80
+            :path "/index.html"})))
   (let [uri-string "http://www.domain.net/with?query=and#fragment"]
     (is (= (into {} (uri uri-string))
            (into {} (uri (URI. uri-string)))


### PR DESCRIPTION
This attempts to support IPv6 addresses in square brackets as hostnames in URLs in accordance with RFC 2732. I'm doing this not for sport but because I encountered such URLs in the wild, and they caused a NumberFormatException. See #19, which this resolves.